### PR TITLE
fix: 10 项用户反馈改进（注入超时防卡死 / 模型下载路径可选 / UIPI 分流等）

### DIFF
--- a/apps/desktop/src-tauri/src/hotkey.rs
+++ b/apps/desktop/src-tauri/src/hotkey.rs
@@ -527,9 +527,8 @@ fn backend_preference(app: &AppHandle) -> HotkeyBackend {
         .unwrap_or_default()
 }
 
-/// 检测与常见游戏键位的冲突（首次启动引导用）。
+/// 检测与常见游戏键位的冲突（首次启动引导用，P2-⑩ 已接入向导热键步骤）。
 /// TODO(后续)：与常见游戏默认键位表对比 + 尝试注册探测占用情况。当前仅做静态提示。
-#[allow(dead_code)] // 供首次启动引导 UI 调用（前端子代理接入）
 pub fn detect_conflicts(key: &str) -> Vec<String> {
     let common_game_keys = [
         "F1", "F2", "F3", "F4", "F5", "F6", "F7", "F9", "F10", "F11", "F12", "Tab", "Space",

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -805,6 +805,12 @@ async fn check_input_environment(app: AppHandle) -> Result<InputEnvironmentCheck
     .map_err(|e| format!("输入环境自检任务失败：{e}"))
 }
 
+/// 静态键位冲突提示（P2-⑩：向导热键步骤录入后展示；常见游戏键位表）
+#[tauri::command]
+fn detect_hotkey_conflicts(key: String) -> Vec<String> {
+    crate::hotkey::detect_conflicts(&key)
+}
+
 /// 开始热键捕获（设置页「点击录入」）：结果经 `kotone://hotkey-capture` 事件推送
 #[tauri::command]
 async fn start_hotkey_capture(app: AppHandle) -> Result<(), String> {
@@ -1475,6 +1481,7 @@ pub fn run() {
             get_elevation_status,
             get_hotkey_status,
             check_input_environment,
+            detect_hotkey_conflicts,
             start_hotkey_capture,
             cancel_hotkey_capture,
             restart_as_admin,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1162,10 +1162,15 @@ async fn cancel_session(state: tauri::State<'_, SharedState>) -> Result<(), Stri
 }
 
 /// 手动触发发送（调试/记事本测试用）：走真实 WindowsInjector 时序
-/// （openChatKey → Unicode/剪贴板 → sendKey，直发当前前台窗口）
+/// （openChatKey → Unicode/剪贴板 → sendKey，直发当前前台窗口）。
+///
+/// P0（用户反馈「SendInput 被 360 拦截后卡死」）：此前是同步命令，在主线程
+/// 直接调 SendInput——被安全软件钩住挂起时整个主进程（UI/托盘/IPC）冻结。
+/// 改为 async + spawn_blocking + 10s 超时：挂起只阻塞工作线程，超时后返回
+/// 清晰错误，UI 保持响应。
 #[tauri::command]
-fn simulate_send(
-    state: tauri::State<SharedState>,
+async fn simulate_send(
+    state: tauri::State<'_, SharedState>,
     text: String,
     profile_id: Option<String>,
 ) -> Result<(), InjectError> {
@@ -1173,7 +1178,18 @@ fn simulate_send(
         .as_deref()
         .and_then(profile::get)
         .unwrap_or_else(GameProfile::builtin_generic);
-    state.injector.send(&text, &profile, CancelToken::default())
+    let injector = state.injector.clone();
+    let task = tauri::async_runtime::spawn_blocking(move || {
+        injector.send(&text, &profile, CancelToken::default())
+    });
+    const SEND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+    match tokio::time::timeout(SEND_TIMEOUT, task).await {
+        Ok(Ok(result)) => result,
+        Ok(Err(_)) => Err(InjectError::new("发送线程异常".to_string())),
+        Err(_) => Err(InjectError::new(
+            "发送超时（10s）：模拟输入未在限时内完成，通常是被安全软件或游戏反作弊拦截".to_string(),
+        )),
+    }
 }
 
 /// 自启动提权（§10 R-1）：设置开启且当前未提权时，runas 重启自身并立即退出。

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1092,6 +1092,14 @@ fn delete_model(
     Ok(outcome)
 }
 
+/// 在系统文件管理器中打开历史记录目录（P2-⑨：历史目录可自定义后仍需可视入口）
+#[tauri::command]
+fn open_history_dir() -> Result<(), String> {
+    let dir = kotone_core::history::history_dir();
+    std::fs::create_dir_all(&dir).map_err(|e| format!("无法创建目录 {}：{e}", dir.display()))?;
+    open_in_file_manager(&dir)
+}
+
 /// 在系统文件管理器中打开模型目录
 #[tauri::command]
 fn open_models_dir(state: tauri::State<SharedState>) -> Result<(), String> {
@@ -1481,6 +1489,7 @@ pub fn run() {
             set_models_dir,
             delete_model,
             open_models_dir,
+            open_history_dir,
             open_external,
             get_history,
             clear_history,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -843,8 +843,29 @@ fn list_models() -> Result<Vec<model::ModelInfo>, String> {
 /// 下载模型（id = 清单内任意模型 / silero-vad；镜像策略见 settings.download）。
 /// 进度经 "kotone://download" 事件外发：{ id, downloaded, total }。
 /// async 命令 + spawn_blocking：大模型下载不阻塞 UI 线程；IPC 签名不变。
+/// 下载前做磁盘空间预检（P2-⑦）：目标目录所在卷剩余空间不足时直接拒绝，
+/// 避免下载到一半才发现 C 盘/目标盘已满。
 #[tauri::command]
-async fn download_model(app: AppHandle, id: String) -> Result<(), String> {
+async fn download_model(
+    app: AppHandle,
+    state: tauri::State<'_, SharedState>,
+    id: String,
+) -> Result<(), String> {
+    // 磁盘空间预检：模型体积 vs 模型目录所在卷可用空间
+    if let (Some(need), Some(dir)) = (model::model_size_bytes(&id), Some(model_dir_now(&state))) {
+        if let Some(avail) = disk_available_space(&dir) {
+            if avail < need {
+                let mb = |b: u64| b / 1_000_000;
+                return Err(format!(
+                    "磁盘空间不足：模型需要约 {} MB，但「{}」所在磁盘仅剩 {} MB。\
+                     请清理磁盘或在设置中更换模型存储位置",
+                    mb(need),
+                    dir.display(),
+                    mb(avail)
+                ));
+            }
+        }
+    }
     let case_id = format!(
         "model-download-{}-{}",
         id,
@@ -899,6 +920,31 @@ async fn download_model(app: AppHandle, id: String) -> Result<(), String> {
         }),
     );
     result
+}
+
+/// 当前生效模型目录（磁盘预检用）
+fn model_dir_now(state: &tauri::State<'_, SharedState>) -> std::path::PathBuf {
+    let settings = state.settings.read().unwrap();
+    model::models_dir_from(&settings)
+}
+
+/// 路径所在卷的可用空间（sysinfo Disks；取最长挂载前缀匹配；失败返回 None 不阻断下载）
+fn disk_available_space(path: &std::path::Path) -> Option<u64> {
+    use sysinfo::Disks;
+    let disks = Disks::new_with_refreshed_list();
+    let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    disks
+        .iter()
+        .filter(|d| canonical.starts_with(d.mount_point()))
+        .max_by_key(|d| d.mount_point().as_os_str().len())
+        .map(|d| d.available_space())
+}
+
+/// 请求取消进行中的模型下载（幂等；.part 保留可续传）
+#[tauri::command]
+fn cancel_download() {
+    model::cancel_download();
+    log::log("download cancel requested");
 }
 
 #[tauri::command]
@@ -1417,6 +1463,7 @@ pub fn run() {
             restart_as_admin,
             list_models,
             download_model,
+            cancel_download,
             set_active_model,
             get_runtime_status,
             start_runtime,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1027,12 +1027,21 @@ pub struct ModelsDirMigration {
 /// 切换模型存储目录：先把旧目录内容移动到新目录（跨卷回退复制），
 /// 迁移完成后才写配置——迁移失败过半也不丢配置一致性（failed 条目需重新下载）。
 /// 传空字符串 = 恢复默认 ~/.kotone/models。
+/// 运行时 Running 期间拒绝迁移：模型文件被引擎占用（Windows 文件锁），
+/// 迁移必然失败且产生困惑的 failed 列表（P2-⑧）。
 #[tauri::command]
 fn set_models_dir(
     app: AppHandle,
     state: tauri::State<SharedState>,
     dir: String,
 ) -> Result<ModelsDirMigration, String> {
+    let running = app
+        .try_state::<RuntimeManager>()
+        .map(|rt| rt.phase() == RuntimePhase::Running)
+        .unwrap_or(false);
+    if running {
+        return Err("引擎正在运行，请先停止引擎再迁移模型目录（设置页或托盘「停止引擎」）".into());
+    }
     let (old_dir, new_dir) = {
         let settings = state.settings.read().unwrap();
         let old = model::models_dir_from(&settings);

--- a/apps/desktop/src/lib/components/OverlayBar.svelte
+++ b/apps/desktop/src/lib/components/OverlayBar.svelte
@@ -408,6 +408,11 @@
         {:else if $appState.errorText}
           <p class="mt-0.5 truncate text-[11px] text-white/50">保留文本：{$appState.errorText}</p>
         {/if}
+        {#if $appState.needsElevation}
+          <p class="mt-0.5 text-[11px] text-kotone-cyan/85">
+            目标程序权限更高：请以管理员身份运行 Kotone 后重试
+          </p>
+        {/if}
       </div>
       <div class="flex shrink-0 gap-1.5">
         {#if $appState.errorText}

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -720,6 +720,12 @@ export interface HotkeyCaptureEvent {
   timeout?: boolean;
 }
 
+/** 静态键位冲突提示（向导热键步骤；常见游戏键位表） */
+export async function detectHotkeyConflicts(key: string): Promise<string[]> {
+  if (!isTauri) return [];
+  return invoke<string[]>("detect_hotkey_conflicts", { key });
+}
+
 /** 开始热键捕获（设置页「点击录入」）；结果经 kotone://hotkey-capture 事件推送 */
 export async function startHotkeyCapture(): Promise<void> {
   if (!isTauri) throw new Error("浏览器调试环境不支持热键录入");

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -870,6 +870,15 @@ export async function downloadModel(id: string): Promise<void> {
   return invoke<void>("download_model", { id });
 }
 
+/** 取消进行中的模型下载（幂等；已下载部分保留可续传） */
+export async function cancelDownload(): Promise<void> {
+  if (!isTauri) {
+    console.info("[mock] cancel_download");
+    return;
+  }
+  return invoke<void>("cancel_download");
+}
+
 /** 切换引擎的活动模型（Running 时置 restartNeeded，不自动重启） */
 export async function setActiveModel(engineId: string, modelId: string): Promise<void> {
   if (!isTauri) {

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -42,6 +42,8 @@ export interface HistoryConfig {
   maxRecords: number;
   /** 是否随记录独立保存音频（不依赖评测录档） */
   includeAudio: boolean;
+  /** 自定义历史目录（含音频）；空 = 默认 ~/.kotone/history */
+  dir: string;
 }
 
 export interface Settings {
@@ -311,7 +313,7 @@ const mock: MockStore = {
     channelCycleHotkey: "Shift+CapsLock",
     interactionMode: "push-to-talk",
     vadSilenceMs: 700,
-    history: { mode: "capped", maxRecords: 1000, includeAudio: false },
+    history: { mode: "capped", maxRecords: 1000, includeAudio: false, dir: "" },
     ui: { firstRunCompleted: true, autoStart: false },
     models: { dir: "" },
     download: { source: "auto", ghProxy: "https://ghfast.top/" },
@@ -827,6 +829,15 @@ export async function openModelsDir(): Promise<void> {
     return;
   }
   return invoke<void>("open_models_dir");
+}
+
+/** 在系统文件管理器中打开历史记录目录（P2-⑨） */
+export async function openHistoryDir(): Promise<void> {
+  if (!isTauri) {
+    console.info("[mock] open_history_dir");
+    return;
+  }
+  return invoke<void>("open_history_dir");
 }
 
 /** 在系统默认浏览器打开外部链接（dev:web 直接 window.open 新标签页） */

--- a/apps/desktop/src/lib/stores/state.ts
+++ b/apps/desktop/src/lib/stores/state.ts
@@ -41,6 +41,8 @@ export interface AppState {
   errorText: string | null;
   /** error 是否为「模拟输入被系统拦截」（安全软件/反作弊）；true 时弹排查引导弹窗 */
   inputBlocked: boolean;
+  /** error 是否为 UIPI 提权问题（目标程序以更高权限运行）；true 时提示管理员运行 */
+  needsElevation: boolean;
   /** 当前聊天频道（多频道 profile 才有值；切回默认时为 null 让悬浮窗隐藏徽标） */
   channel: ChannelInfo | null;
 }
@@ -53,6 +55,7 @@ const initial: AppState = {
   errorMessage: null,
   errorText: null,
   inputBlocked: false,
+  needsElevation: false,
   channel: null,
 };
 
@@ -66,6 +69,7 @@ interface StateEventPayload {
     text?: string | null;
     message?: string | null;
     inputBlocked?: boolean | null;
+    needsElevation?: boolean | null;
   } | null;
 }
 
@@ -94,6 +98,7 @@ function applyStateEvent(ev: StateEventPayload): void {
         next.errorMessage = null;
         next.errorText = null;
         next.inputBlocked = false;
+        next.needsElevation = false;
         break;
       case "listening":
         // 新会话开始：清空上一轮残留
@@ -102,6 +107,7 @@ function applyStateEvent(ev: StateEventPayload): void {
         next.errorMessage = null;
         next.errorText = null;
         next.inputBlocked = false;
+        next.needsElevation = false;
         break;
       case "transcribing":
         // 保留 partial 上屏内容，等待最终文本
@@ -118,6 +124,7 @@ function applyStateEvent(ev: StateEventPayload): void {
       case "error":
         next.errorMessage = message ?? "未知错误";
         next.inputBlocked = ev.payload?.inputBlocked === true;
+        next.needsElevation = ev.payload?.needsElevation === true;
         if (text) next.errorText = text;
         break;
     }

--- a/apps/desktop/src/routes/settings/Onboarding.svelte
+++ b/apps/desktop/src/routes/settings/Onboarding.svelte
@@ -4,6 +4,7 @@
   import {
     checkInputEnvironment,
     cancelDownload,
+    detectHotkeyConflicts,
     downloadModel,
     getModelsDir,
     isTauri,
@@ -289,6 +290,7 @@
       if (result.kind === "combo") {
         currentKey = result.combo;
         toast(true, `已录入热键：${result.combo}`);
+        void checkHotkeyConflicts(result.combo);
       } else if (result.kind === "cancelled") {
         toastInfo("已取消录入");
       } else if (result.kind === "timeout") {
@@ -297,6 +299,16 @@
         toast(false, result.message);
       }
     });
+  }
+
+  /** 键位冲突静态提示（P2-⑩：录入后展示常见游戏键位冲突） */
+  let hotkeyWarnings = $state<string[]>([]);
+  async function checkHotkeyConflicts(key: string) {
+    try {
+      hotkeyWarnings = await detectHotkeyConflicts(key);
+    } catch {
+      hotkeyWarnings = [];
+    }
   }
 
   async function saveInteractionAndContinue() {
@@ -689,6 +701,15 @@
             {capturing ? "请按下组合键…（Esc 取消）" : "重新录入"}
           </button>
         </div>
+
+        {#if hotkeyWarnings.length > 0}
+          <div class="mt-3 rounded-xl bg-kotone-pink/10 p-3 ring-1 ring-kotone-pink/35">
+            <p class="text-xs font-semibold text-kotone-pink">键位冲突提示</p>
+            {#each hotkeyWarnings as w}
+              <p class="mt-1 text-[11px] leading-relaxed text-white/65">⚠ {w}</p>
+            {/each}
+          </div>
+        {/if}
 
         <div class="mt-6 flex items-center justify-between">
           <button class="text-xs text-white/50 hover:text-white/80" onclick={() => (step = 2)}>

--- a/apps/desktop/src/routes/settings/Onboarding.svelte
+++ b/apps/desktop/src/routes/settings/Onboarding.svelte
@@ -3,6 +3,7 @@
   import { listen } from "@tauri-apps/api/event";
   import {
     checkInputEnvironment,
+    cancelDownload,
     downloadModel,
     getModelsDir,
     isTauri,
@@ -229,6 +230,15 @@
       downloadTargetId = null;
       unlistenDl?.();
       unlistenDl = undefined;
+    }
+  }
+
+  /** 取消下载（.part 保留，可续传；P2-⑦） */
+  async function cancelDownloadById() {
+    try {
+      await cancelDownload();
+    } catch (e) {
+      toast(false, `取消失败：${errText(e)}`);
     }
   }
 
@@ -486,13 +496,21 @@
               {/if}
             </div>
             {#if downloadTargetId === primaryModel.id}
-              <div class="mt-3 h-1.5 overflow-hidden rounded-full bg-white/10">
-                <div
-                  class="h-full rounded-full bg-kotone-cyan transition-[width] {dlPercent === null
-                    ? 'w-1/3 animate-pulse'
-                    : ''}"
-                  style:width={dlPercent === null ? undefined : `${dlPercent}%`}
-                ></div>
+              <div class="mt-3 flex items-center gap-2">
+                <div class="h-1.5 flex-1 overflow-hidden rounded-full bg-white/10">
+                  <div
+                    class="h-full rounded-full bg-kotone-cyan transition-[width] {dlPercent === null
+                      ? 'w-1/3 animate-pulse'
+                      : ''}"
+                    style:width={dlPercent === null ? undefined : `${dlPercent}%`}
+                  ></div>
+                </div>
+                <button
+                  class="shrink-0 rounded-lg bg-white/10 px-2.5 py-1 text-[11px] text-white/70 ring-1 ring-white/15 transition hover:bg-white/20"
+                  onclick={() => void cancelDownloadById()}
+                >
+                  取消
+                </button>
               </div>
               <p class="mt-1.5 text-[11px] text-white/45">
                 {dlPercent === null ? "建立连接中…" : `${dlPercent}%`}

--- a/apps/desktop/src/routes/settings/Onboarding.svelte
+++ b/apps/desktop/src/routes/settings/Onboarding.svelte
@@ -4,11 +4,14 @@
   import {
     checkInputEnvironment,
     downloadModel,
+    getModelsDir,
     isTauri,
     listAudioDevices,
     listModels,
     listProfiles,
+    openModelsDir,
     setAudioDevice,
+    setModelsDir,
     updateSettings,
     type AudioDevice,
     type DownloadProgress,
@@ -16,7 +19,9 @@
     type InputEnvironmentCheck,
     type InteractionMode,
     type ModelInfo,
+    type ModelsDirInfo,
   } from "../../lib/ipc";
+  import { open as openDialog } from "@tauri-apps/plugin-dialog";
   import { captureHotkey } from "../../lib/hotkeyCapture";
   import {
     errText,
@@ -39,6 +44,9 @@
   let profiles = $state<GameProfile[]>([]);
   let devices = $state<AudioDevice[]>([]);
   let downloadedIds = $state<string[]>([]);
+  /** 模型存储位置（用户反馈：下载模型应支持选择路径，而不是默认 C 盘） */
+  let dirInfo = $state<ModelsDirInfo | null>(null);
+  let changingDir = $state(false);
 
   const primaryModel = $derived(
     models.find((m) => m.engineId === "sherpa-onnx-x-asr-zh-en") ?? null,
@@ -83,12 +91,68 @@
       selectedDeviceId = settings?.audioDeviceId ?? devices[0]?.id ?? "default";
       selectedMode = settings?.interactionMode ?? "push-to-talk";
       currentKey = settings?.hotkey.key ?? "CapsLock";
+      getModelsDir()
+        .then((d) => (dirInfo = d))
+        .catch((e) => console.error("[onboarding] get_models_dir 失败：", e));
     } catch (e) {
       resourceError = errText(e);
     } finally {
       loadingResources = false;
     }
   });
+
+  /** 选择自定义模型存储目录（下载前可先迁移，避免模型落到 C 盘） */
+  async function pickModelsDir() {
+    if (changingDir) return;
+    let picked: string | null = null;
+    if (isTauri) {
+      const sel = await openDialog({ directory: true, title: "选择模型存储位置" }).catch(
+        () => null,
+      );
+      if (!sel) return; // 用户取消
+      picked = sel;
+    } else {
+      picked = window.prompt("模型存储目录（开发预览模式）", dirInfo?.dir ?? "");
+      if (!picked) return;
+    }
+    changingDir = true;
+    try {
+      const report = await setModelsDir(picked);
+      if (report.failed.length > 0) {
+        toastWarn(
+          `目录已切换，但 ${report.failed.length} 项迁移失败（需重新下载）：${report.failed.join(", ")}`,
+        );
+      } else {
+        toast(
+          true,
+          report.moved.length > 0 ? `模型目录已切换，迁移 ${report.moved.length} 项` : "模型目录已切换",
+        );
+      }
+      dirInfo = await getModelsDir();
+    } catch (e) {
+      toast(false, `切换模型目录失败：${errText(e)}`);
+    } finally {
+      changingDir = false;
+    }
+  }
+
+  /** 恢复默认目录（~/.kotone/models） */
+  async function resetModelsDir() {
+    if (changingDir) return;
+    changingDir = true;
+    try {
+      const report = await setModelsDir("");
+      toast(
+        true,
+        report.moved.length > 0 ? `已恢复默认目录，迁移 ${report.moved.length} 项` : "已恢复默认目录",
+      );
+      dirInfo = await getModelsDir();
+    } catch (e) {
+      toast(false, `恢复默认目录失败：${errText(e)}`);
+    } finally {
+      changingDir = false;
+    }
+  }
 
   async function reloadResources() {
     loadingResources = true;
@@ -436,6 +500,43 @@
             <p class="text-xs text-kotone-pink">未找到推荐模型，请重试读取资源。</p>
           {/if}
         </div>
+
+        <!-- 模型存储位置（用户反馈：下载模型应支持选择路径而非默认 C 盘） -->
+        <label class="kotone-card mt-3 block p-4">
+          <span class="text-sm font-semibold text-kotone-cyan/90">模型存储位置</span>
+          <span class="mt-2 block text-[11px] text-white/45">
+            模型体积较大（推荐模型约 134 MB），建议放到空间充足的磁盘。切换后已下载的模型会一并迁移。
+          </span>
+          <span
+            class="mt-2 block truncate rounded-lg bg-white/5 px-2.5 py-1.5 text-xs text-white/70 ring-1 ring-white/10"
+          >
+            {dirInfo?.dir ?? "读取中…"}{dirInfo?.isDefault ? "（默认）" : ""}
+          </span>
+          <div class="mt-2 flex items-center gap-2">
+            <button
+              class="rounded-lg bg-white/10 px-3 py-1.5 text-xs font-semibold text-white/85 ring-1 ring-white/15 transition hover:bg-white/20 disabled:opacity-50"
+              disabled={changingDir || dirInfo === null}
+              onclick={() => void pickModelsDir()}
+            >
+              {changingDir ? "切换中…" : "选择位置"}
+            </button>
+            {#if dirInfo && !dirInfo.isDefault}
+              <button
+                class="rounded-lg bg-white/10 px-3 py-1.5 text-xs text-white/70 ring-1 ring-white/15 transition hover:bg-white/20 disabled:opacity-50"
+                disabled={changingDir}
+                onclick={() => void resetModelsDir()}
+              >
+                恢复默认
+              </button>
+            {/if}
+            <button
+              class="ml-auto rounded-lg bg-white/10 px-3 py-1.5 text-xs text-white/70 ring-1 ring-white/15 transition hover:bg-white/20"
+              onclick={() => void openModelsDir()}
+            >
+              打开目录
+            </button>
+          </div>
+        </label>
 
         <label class="kotone-card mt-3 block p-4">
           <span class="text-sm font-semibold text-kotone-cyan/90">麦克风</span>

--- a/apps/desktop/src/routes/settings/Onboarding.svelte
+++ b/apps/desktop/src/routes/settings/Onboarding.svelte
@@ -282,7 +282,11 @@
   }
 
   async function startCapture() {
-    if (capturing || checkingInputEnvironment || inputEnvironment?.available === false) return;
+    if (
+      capturing ||
+      checkingInputEnvironment ||
+      (inputEnvironment?.available === false && !inputBlockedOverridden)
+    ) return;
     capturing = true;
     captureCleanup = await captureHotkey((result) => {
       capturing = false;

--- a/apps/desktop/src/routes/settings/Onboarding.svelte
+++ b/apps/desktop/src/routes/settings/Onboarding.svelte
@@ -236,6 +236,8 @@
   let captureCleanup: (() => void) | null = null;
   let checkingInputEnvironment = $state(false);
   let inputEnvironment = $state<InputEnvironmentCheck | null>(null);
+  /** 拦截逃生门：探针判定拦截时用户仍可选择「仍然继续」（风险自担），不被卡在向导里 */
+  let inputBlockedOverridden = $state(false);
 
   async function runInputEnvironmentCheck() {
     if (checkingInputEnvironment) return;
@@ -632,6 +634,15 @@
             >
               已加入信任区，重新检测
             </button>
+            <button
+              class="mt-3 rounded-lg bg-white/10 px-3 py-1.5 text-xs text-white/70 ring-1 ring-white/15 transition hover:bg-white/20"
+              onclick={() => {
+                inputBlockedOverridden = true;
+                toastWarn("已跳过输入环境检测：如后续发送无反应，请回此步重新检测");
+              }}
+            >
+              仍然继续（风险自担）
+            </button>
           </div>
         {:else if inputEnvironment}
           <div
@@ -654,7 +665,7 @@
           </div>
           <button
             class="rounded-lg bg-white/10 px-3 py-2 text-xs font-semibold text-white/85 ring-1 ring-white/15 hover:bg-white/20 disabled:opacity-60"
-            disabled={capturing || checkingInputEnvironment || inputEnvironment?.available === false}
+            disabled={capturing || checkingInputEnvironment || (inputEnvironment?.available === false && !inputBlockedOverridden)}
             onclick={() => void startCapture()}
           >
             {capturing ? "请按下组合键…（Esc 取消）" : "重新录入"}
@@ -667,7 +678,7 @@
           </button>
           <button
             class="rounded-lg bg-kotone-cyan px-5 py-2 text-sm font-semibold text-kotone-deep transition hover:brightness-110 disabled:opacity-50"
-            disabled={capturing || checkingInputEnvironment || inputEnvironment?.available === false}
+            disabled={capturing || checkingInputEnvironment || (inputEnvironment?.available === false && !inputBlockedOverridden)}
             onclick={() => void saveInteractionAndContinue()}
           >
             完成

--- a/apps/desktop/src/routes/settings/pages/AdvancedPage.svelte
+++ b/apps/desktop/src/routes/settings/pages/AdvancedPage.svelte
@@ -20,6 +20,7 @@
     getModelsDir,
     setModelsDir,
     openModelsDir,
+    openHistoryDir,
     cancelDownload,
     updateSettings,
     getElevationStatus,
@@ -164,6 +165,28 @@
     const sel = await openDialog({ directory: true, title: "选择模型存储位置" }).catch(() => null);
     if (!sel) return; // 用户取消
     dirDraft = sel;
+  }
+
+  // ---------- 历史记录位置（P2-⑨） ----------
+
+  /** 当前历史目录（自定义或默认路径拼接；仅展示用） */
+  const historyDirLabel = $derived(
+    $settingsStore?.history.dir.trim() || "~/.kotone/history",
+  );
+  const historyDirCustom = $derived(Boolean($settingsStore?.history.dir.trim()));
+
+  async function onChangeHistoryDir() {
+    const sel = await openDialog({ directory: true, title: "选择历史记录位置" }).catch(() => null);
+    if (!sel) return; // 用户取消
+    await patch({ history: { dir: sel } }, "历史目录已切换");
+  }
+
+  async function onOpenHistoryDir() {
+    try {
+      await openHistoryDir();
+    } catch (e) {
+      toast(false, `打开目录失败：${errText(e)}`);
+    }
   }
 
   // ---------- 模型操作 ----------
@@ -478,6 +501,39 @@
         </button>
       </div>
     {/if}
+  </section>
+
+  <!-- 历史记录位置（P2-⑨：历史音频也可能占大量空间，支持自定义目录） -->
+  <section class="kotone-panel mt-4 p-4">
+    <h2 class="text-sm font-semibold text-kotone-cyan/90">历史记录位置</h2>
+    <div class="mt-3 flex items-center gap-2">
+      <span class="min-w-0 flex-1 truncate rounded-lg bg-white/5 px-2.5 py-1.5 text-xs text-white/70 ring-1 ring-white/10">
+        {historyDirLabel}{historyDirCustom ? "" : "（默认）"}
+      </span>
+      <button
+        class="shrink-0 rounded-lg bg-white/10 px-3 py-1.5 text-xs font-semibold text-white/85 ring-1 ring-white/15 transition hover:bg-white/20"
+        onclick={() => void onChangeHistoryDir()}
+      >
+        更改
+      </button>
+      {#if historyDirCustom}
+        <button
+          class="shrink-0 rounded-lg bg-white/10 px-3 py-1.5 text-xs text-white/70 ring-1 ring-white/15 transition hover:bg-white/20"
+          onclick={() => void patch({ history: { dir: "" } }, "已恢复默认历史目录")}
+        >
+          恢复默认
+        </button>
+      {/if}
+      <button
+        class="shrink-0 rounded-lg bg-white/10 px-3 py-1.5 text-xs font-semibold text-white/85 ring-1 ring-white/15 transition hover:bg-white/20"
+        onclick={() => void onOpenHistoryDir()}
+      >
+        打开目录
+      </button>
+    </div>
+    <p class="mt-2 text-[11px] text-white/40">
+      历史记录与回放音频保存位置；新记录写入新目录，旧目录内容不自动迁移。
+    </p>
   </section>
 
   {#if engines === null}

--- a/apps/desktop/src/routes/settings/pages/AdvancedPage.svelte
+++ b/apps/desktop/src/routes/settings/pages/AdvancedPage.svelte
@@ -20,6 +20,7 @@
     getModelsDir,
     setModelsDir,
     openModelsDir,
+    cancelDownload,
     updateSettings,
     getElevationStatus,
     getHotkeyStatus,
@@ -181,6 +182,15 @@
       toast(false, "下载失败，可在模型卡片中重试或调整下载源");
     } finally {
       delete dlProgress[id];
+    }
+  }
+
+  /** 取消进行中的下载（.part 保留可续传；P2-⑦） */
+  async function onCancelDownload(id: string) {
+    try {
+      await cancelDownload();
+    } catch (e) {
+      toast(false, `取消失败：${errText(e)}`);
     }
   }
 
@@ -584,15 +594,23 @@
                       </button>
                     </div>
                     {#if m.id in dlProgress}
-                      <div class="mt-2 h-1.5 overflow-hidden rounded-full bg-white/10">
-                        {#if dlProgress[m.id] !== null}
-                          <div
-                            class="h-full rounded-full bg-kotone-violet transition-[width]"
-                            style:width="{dlProgress[m.id]}%"
-                          ></div>
-                        {:else}
-                          <div class="h-full w-1/3 animate-pulse rounded-full bg-kotone-violet/70"></div>
-                        {/if}
+                      <div class="mt-2 flex items-center gap-2">
+                        <div class="h-1.5 flex-1 overflow-hidden rounded-full bg-white/10">
+                          {#if dlProgress[m.id] !== null}
+                            <div
+                              class="h-full rounded-full bg-kotone-violet transition-[width]"
+                              style:width="{dlProgress[m.id]}%"
+                            ></div>
+                          {:else}
+                            <div class="h-full w-1/3 animate-pulse rounded-full bg-kotone-violet/70"></div>
+                          {/if}
+                        </div>
+                        <button
+                          class="shrink-0 rounded-lg bg-white/10 px-2.5 py-1 text-[11px] text-white/70 ring-1 ring-white/15 transition hover:bg-white/20"
+                          onclick={() => void onCancelDownload(m.id)}
+                        >
+                          取消
+                        </button>
                       </div>
                     {/if}
                     {#if dlErrors[m.id]}

--- a/apps/desktop/src/routes/settings/pages/AdvancedPage.svelte
+++ b/apps/desktop/src/routes/settings/pages/AdvancedPage.svelte
@@ -9,7 +9,7 @@
    */
   import { onDestroy, onMount } from "svelte";
   import { listen } from "@tauri-apps/api/event";
-  import { save as saveDialog } from "@tauri-apps/plugin-dialog";
+  import { open as openDialog, save as saveDialog } from "@tauri-apps/plugin-dialog";
   import {
     listSttEngines,
     exportDiagnostics,
@@ -156,6 +156,13 @@
     } catch (e) {
       toast(false, `打开目录失败：${errText(e)}`);
     }
+  }
+
+  /** 文件夹选择器（用户反馈：模型路径应支持可视化选择而非手输） */
+  async function onBrowseDir() {
+    const sel = await openDialog({ directory: true, title: "选择模型存储位置" }).catch(() => null);
+    if (!sel) return; // 用户取消
+    dirDraft = sel;
   }
 
   // ---------- 模型操作 ----------
@@ -416,6 +423,12 @@
           spellcheck="false"
           class="min-w-0 flex-1 rounded-lg bg-white/8 px-2.5 py-1.5 text-xs ring-1 ring-white/15 outline-none placeholder:text-white/30 focus:ring-kotone-cyan/60"
         />
+        <button
+          class="shrink-0 rounded-lg bg-white/10 px-3 py-1.5 text-xs text-white/75 ring-1 ring-white/15 transition hover:bg-white/20"
+          onclick={() => void onBrowseDir()}
+        >
+          浏览…
+        </button>
         <button
           class="shrink-0 rounded-lg bg-kotone-cyan px-3 py-1.5 text-xs font-semibold text-kotone-deep transition hover:brightness-110 active:scale-95 disabled:opacity-50"
           disabled={migrating}

--- a/apps/desktop/src/routes/settings/pages/GeneralPage.svelte
+++ b/apps/desktop/src/routes/settings/pages/GeneralPage.svelte
@@ -11,11 +11,17 @@
     getElevationStatus,
     restartAsAdmin,
     getHotkeyStatus,
+    listModels,
+    downloadModel,
     type AudioDevice,
+    type DownloadProgress,
     type ElevationStatus,
     type HotkeyStatus,
     type InteractionMode,
+    type ModelInfo,
   } from "../../../lib/ipc";
+  import { listen } from "@tauri-apps/api/event";
+  import { isTauri } from "../../../lib/ipc";
   import { captureHotkey } from "../../../lib/hotkeyCapture";
   import { combosConflict } from "../../../lib/hotkeyCombo";
   import { settingsStore, toast, errText } from "../../../lib/stores/ui";
@@ -30,6 +36,54 @@
   let elevation = $state<ElevationStatus | null>(null);
   let restarting = $state(false);
 
+  // ---------- 模型未下载时的主页直达下载入口（P2-⑥：向导跳过后的补救路径） ----------
+  let models = $state<ModelInfo[]>([]);
+  let downloading = $state(false);
+  let dlProgress = $state<{ downloaded: number; total: number } | null>(null);
+  let unlistenDl: (() => void) | undefined;
+
+  const primaryModel = $derived(
+    models.find((m) => m.engineId === "sherpa-onnx-x-asr-zh-en") ?? null,
+  );
+  /** 推荐模型缺失 = 需要下载（向导被跳过或模型被删除） */
+  const modelMissing = $derived(primaryModel !== null && !primaryModel.downloaded);
+  const dlPercent = $derived(
+    dlProgress && dlProgress.total > 0
+      ? Math.min(100, Math.round((dlProgress.downloaded / dlProgress.total) * 100))
+      : null,
+  );
+
+  async function downloadPrimaryModel() {
+    if (downloading || !primaryModel) return;
+    downloading = true;
+    dlProgress = null;
+    try {
+      if (isTauri) {
+        unlistenDl = await listen<DownloadProgress>("kotone://download", (ev) => {
+          if (ev.payload.id === primaryModel.id) {
+            dlProgress = {
+              downloaded: ev.payload.downloaded,
+              total: ev.payload.total,
+            };
+          }
+        });
+      }
+      await downloadModel(primaryModel.id);
+      models = models.map((m) => (m.id === primaryModel.id ? { ...m, downloaded: true } : m));
+      toast(true, "模型下载完成，可以启动引擎了");
+    } catch (e) {
+      toast(false, `模型下载失败：${errText(e)}`);
+    } finally {
+      downloading = false;
+      unlistenDl?.();
+      unlistenDl = undefined;
+    }
+  }
+
+  onDestroy(() => {
+    unlistenDl?.();
+  });
+
   /** 提权重启接力标记：旧进程退出前落 localStorage，新进程检测到已提权后 toast 并清除 */
   const ADMIN_RESTART_FLAG = "kotone:admin-restart-pending";
 
@@ -42,6 +96,11 @@
       }
     } catch (e) {
       toast(false, `加载设备信息失败：${errText(e)}`);
+    }
+    try {
+      models = await listModels();
+    } catch (e) {
+      console.error("[general] list_models 失败：", e);
     }
   });
 
@@ -264,6 +323,35 @@
       <RuntimeButton variant="hero" {onOpenAdvanced} />
     </div>
   </section>
+
+  <!-- 模型未下载直达下载（P2-⑥：跳过向导/删除模型后的补救入口） -->
+  {#if modelMissing}
+    <section class="kotone-panel mt-4 flex items-center gap-3 p-4 ring-1 ring-kotone-pink/35">
+      <span class="text-xl">📥</span>
+      <div class="min-w-0 flex-1">
+        <p class="text-sm font-semibold text-white/90">还没有可用的识别模型</p>
+        <p class="mt-0.5 text-[11px] text-white/50">
+          下载后即可启动引擎（{primaryModel?.displayName}，约{" "}
+          {primaryModel ? Math.round(primaryModel.sizeBytes / 1_000_000) : 0} MB）
+        </p>
+        {#if dlPercent !== null}
+          <div class="mt-2 h-1.5 overflow-hidden rounded-full bg-white/10">
+            <div
+              class="h-full rounded-full bg-kotone-cyan transition-[width]"
+              style:width="{dlPercent}%"
+            ></div>
+          </div>
+        {/if}
+      </div>
+      <button
+        class="shrink-0 rounded-lg bg-kotone-cyan px-3.5 py-1.5 text-xs font-semibold text-kotone-deep transition hover:brightness-110 active:scale-95 disabled:opacity-60"
+        disabled={downloading}
+        onclick={() => void downloadPrimaryModel()}
+      >
+        {downloading ? "下载中…" : "下载模型"}
+      </button>
+    </section>
+  {/if}
 
   {#if $settingsStore}
     <!-- 麦克风 -->

--- a/apps/desktop/src/routes/settings/pages/GeneralPage.svelte
+++ b/apps/desktop/src/routes/settings/pages/GeneralPage.svelte
@@ -13,6 +13,7 @@
     getHotkeyStatus,
     listModels,
     downloadModel,
+    cancelDownload,
     type AudioDevice,
     type DownloadProgress,
     type ElevationStatus,
@@ -77,6 +78,15 @@
       downloading = false;
       unlistenDl?.();
       unlistenDl = undefined;
+    }
+  }
+
+  /** 取消下载（.part 保留，可续传；P2-⑦） */
+  async function cancelPrimaryDownload() {
+    try {
+      await cancelDownload();
+    } catch (e) {
+      toast(false, `取消失败：${errText(e)}`);
     }
   }
 
@@ -335,11 +345,19 @@
           {primaryModel ? Math.round(primaryModel.sizeBytes / 1_000_000) : 0} MB）
         </p>
         {#if dlPercent !== null}
-          <div class="mt-2 h-1.5 overflow-hidden rounded-full bg-white/10">
-            <div
-              class="h-full rounded-full bg-kotone-cyan transition-[width]"
-              style:width="{dlPercent}%"
-            ></div>
+          <div class="mt-2 flex items-center gap-2">
+            <div class="h-1.5 flex-1 overflow-hidden rounded-full bg-white/10">
+              <div
+                class="h-full rounded-full bg-kotone-cyan transition-[width]"
+                style:width="{dlPercent}%"
+              ></div>
+            </div>
+            <button
+              class="shrink-0 rounded-lg bg-white/10 px-2.5 py-1 text-[11px] text-white/70 ring-1 ring-white/15 transition hover:bg-white/20"
+              onclick={() => void cancelPrimaryDownload()}
+            >
+              取消
+            </button>
           </div>
         {/if}
       </div>

--- a/crates/kotone-core/src/audio.rs
+++ b/crates/kotone-core/src/audio.rs
@@ -23,6 +23,9 @@ pub struct AudioHandle {
     /// Option 包裹便于 orchestrator take 走通道所有权
     pub pcm_rx: Option<mpsc::UnboundedReceiver<Vec<f32>>>,
     pub level_rx: Option<mpsc::UnboundedReceiver<f32>>,
+    /// 采集中途故障（设备被拔出/驱动错误等）：生产实现经此上报错误消息，
+    /// orchestrator 据此中止会话，避免状态机永久停在 Listening
+    pub error_rx: Option<mpsc::UnboundedReceiver<String>>,
     stop_tx: Option<std::sync::mpsc::Sender<()>>,
     thread: Option<std::thread::JoinHandle<()>>,
 }
@@ -36,6 +39,7 @@ impl AudioHandle {
         Self {
             pcm_rx: Some(pcm_rx),
             level_rx: Some(level_rx),
+            error_rx: None,
             stop_tx: None,
             thread: None,
         }
@@ -45,12 +49,14 @@ impl AudioHandle {
     pub fn with_thread(
         pcm_rx: mpsc::UnboundedReceiver<Vec<f32>>,
         level_rx: mpsc::UnboundedReceiver<f32>,
+        error_rx: mpsc::UnboundedReceiver<String>,
         stop_tx: std::sync::mpsc::Sender<()>,
         thread: std::thread::JoinHandle<()>,
     ) -> Self {
         Self {
             pcm_rx: Some(pcm_rx),
             level_rx: Some(level_rx),
+            error_rx: Some(error_rx),
             stop_tx: Some(stop_tx),
             thread: Some(thread),
         }

--- a/crates/kotone-core/src/history.rs
+++ b/crates/kotone-core/src/history.rs
@@ -32,6 +32,10 @@ pub struct HistoryConfig {
     pub max_records: u32,
     /// 是否随记录独立保存音频到 history/audio/（不依赖评测录档）
     pub include_audio: bool,
+    /// 自定义历史目录（含音频）；空 = 默认 ~/.kotone/history（P2-⑨：与模型
+    /// 目录同理，历史音频也可能占用大量空间）
+    #[serde(default)]
+    pub dir: String,
 }
 
 impl Default for HistoryConfig {
@@ -40,6 +44,7 @@ impl Default for HistoryConfig {
             mode: HistoryMode::Capped,
             max_records: 1000,
             include_audio: false,
+            dir: String::new(),
         }
     }
 }
@@ -76,9 +81,15 @@ pub struct HistoryRecord {
 
 // ---------- 路径 ----------
 
-/// 历史数据目录：~/.kotone/history/
+/// 历史数据目录：自定义（settings.history.dir）或默认 ~/.kotone/history/
 pub fn history_dir() -> PathBuf {
-    crate::settings::kotone_dir().join("history")
+    let settings = crate::settings::load();
+    let dir = settings.history.dir.trim();
+    if dir.is_empty() {
+        crate::settings::kotone_dir().join("history")
+    } else {
+        PathBuf::from(dir)
+    }
 }
 
 fn jsonl_path(dir: &Path) -> PathBuf {
@@ -243,6 +254,7 @@ mod tests {
             mode,
             max_records: max,
             include_audio: false,
+            dir: String::new(),
         }
     }
 
@@ -252,6 +264,7 @@ mod tests {
         assert_eq!(c.mode, HistoryMode::Capped);
         assert_eq!(c.max_records, 1000);
         assert!(!c.include_audio);
+        assert!(c.dir.is_empty(), "默认历史目录为空 = ~/.kotone/history");
         // serde 形态：kebab-case 枚举 + camelCase 字段
         let j = serde_json::to_value(&c).unwrap();
         assert_eq!(j["mode"], "capped");

--- a/crates/kotone-core/src/orchestrator.rs
+++ b/crates/kotone-core/src/orchestrator.rs
@@ -17,7 +17,7 @@ use serde_json::json;
 use tokio::sync::{mpsc, oneshot};
 
 use crate::audio::{AudioBackend, AudioHandle};
-use crate::inject::{CancelToken, FocusBackend, Injector, TargetWindow};
+use crate::inject::{CancelToken, FocusBackend, InjectError, Injector, TargetWindow};
 use crate::interaction::{EndTrigger, InteractionPolicy, PostFinalize};
 use crate::profile::{self, GameProfile};
 use crate::settings::Settings;
@@ -25,6 +25,11 @@ use crate::stt::{EngineRegistry, SessionConfig, SttEvent, SttSession};
 
 /// finalize 超时（docs/development.md §6：finalize 设置 10s 超时）
 const DEFAULT_FINALIZE_TIMEOUT: Duration = Duration::from_secs(10);
+/// 注入发送超时：SendInput 被安全软件/反作弊钩住时可能不返回（挂起而非立即 0/N
+/// 失败），没有超时会让状态机永久卡在 Sending、取消也无法打断阻塞线程（用户反馈
+/// 「SendInput 被 360 拦截后软件卡死」）。超时后阻塞线程无法回收，但状态机得以
+/// 回到 Error 态提示用户，避免整机/会话冻结。
+const DEFAULT_INJECT_TIMEOUT: Duration = Duration::from_secs(10);
 /// Success/Error toast 停留时长，之后自动回 Idle
 const DEFAULT_TOAST_DWELL: Duration = Duration::from_millis(1500);
 /// 发送前焦点恢复后的等待：给系统完成前台切换与目标窗口激活的时间
@@ -128,6 +133,8 @@ pub struct Orchestrator {
     me: RwLock<Option<std::sync::Weak<Orchestrator>>>,
     /// finalize 超时（测试可调小）
     pub finalize_timeout: Duration,
+    /// 注入发送超时（测试可调小）：SendInput 挂起时兜底回到 Error 态
+    pub inject_timeout: Duration,
     /// Success/Error 停留时长（测试可设为 0）
     pub toast_dwell: Duration,
     /// 发送前焦点恢复后的等待（测试可设为 0）
@@ -177,6 +184,7 @@ impl Orchestrator {
             emitter,
             me: RwLock::new(None),
             finalize_timeout: DEFAULT_FINALIZE_TIMEOUT,
+            inject_timeout: DEFAULT_INJECT_TIMEOUT,
             toast_dwell: DEFAULT_TOAST_DWELL,
             focus_restore_delay: DEFAULT_FOCUS_RESTORE_DELAY,
             eval_dir: None,
@@ -925,10 +933,28 @@ impl Orchestrator {
             }
         }
 
+        // 注入超时保护（P0，用户反馈「SendInput 被拦截后卡死」）：SendInput 被
+        // 安全软件/反作弊钩住时可能不返回（挂起而非立即 0/N 失败），无超时则
+        // 状态机永久卡 Sending、cancel 无法打断阻塞线程。超时后状态机回 Error
+        // 态（保留文本可重试）；阻塞线程理论上无法回收，靠重启 runtime 清理。
         let injector = self.injector.clone();
-        let result =
-            tokio::task::spawn_blocking(move || injector.send(&wire_text, &wire_profile, token))
-                .await;
+        let send_task =
+            tokio::task::spawn_blocking(move || injector.send(&wire_text, &wire_profile, token));
+        let result = match tokio::time::timeout(self.inject_timeout, send_task).await {
+            Ok(Ok(r)) => r,
+            Ok(Err(_)) => Err(InjectError::new("发送线程异常".to_string())),
+            Err(_) => {
+                crate::log::log(&format!(
+                    "inject send timeout after {}s (SendInput 可能被拦截挂起)",
+                    self.inject_timeout.as_secs()
+                ));
+                Err(InjectError::new(format!(
+                    "发送超时（{}s）：模拟输入未在限时内完成，通常是被安全软件或游戏反作弊拦截。\
+                     可点击重试，或重启引擎后再次尝试",
+                    self.inject_timeout.as_secs()
+                )))
+            }
+        };
 
         let (history_write, resume_continuous) = {
             let _op = self.op.lock().await;
@@ -941,7 +967,7 @@ impl Orchestrator {
             let history_write: (crate::history::HistoryOutcome, Option<String>);
             let mut resume_continuous = false;
             match result {
-                Ok(Ok(())) => {
+                Ok(()) => {
                     inner.preview_text = None;
                     resume_continuous = self.policy().continuous;
                     inner.state = if resume_continuous {
@@ -962,10 +988,11 @@ impl Orchestrator {
                     );
                     history_write = (crate::history::HistoryOutcome::Sent, None);
                 }
-                Ok(Err(e)) => {
+                Err(e) => {
                     // Error 保留文本（preview_text 承载），前端/confirm_send 可重试（§4.1）；
                     // needsElevation 透传 UIPI 提权信号（§10 R-1）；
-                    // inputBlocked 透传「系统级拦截」信号（安全软件/反作弊），前端弹窗引导排查
+                    // inputBlocked 透传「系统级拦截」信号（安全软件/反作弊），前端弹窗引导排查；
+                    // 注入超时（inject_timeout）也落此分支，message 含超时提示
                     inner.preview_text = Some(text.clone());
                     inner.state = OrchestratorState::Error;
                     drop(inner);
@@ -988,27 +1015,6 @@ impl Orchestrator {
                         }),
                     );
                     history_write = (crate::history::HistoryOutcome::Error, Some(e.message));
-                }
-                Err(_) => {
-                    inner.preview_text = Some(text.clone());
-                    inner.state = OrchestratorState::Error;
-                    drop(inner);
-                    self.emit_state(
-                        OrchestratorState::Error,
-                        Some(json!({ "message": "发送线程异常", "text": text })),
-                    );
-                    self.emit_process(
-                        "injection_failed",
-                        json!({
-                            "outcome": "error",
-                            "errorCode": "INJECTION_THREAD_FAILED",
-                            "durationMs": injection_started_at.elapsed().as_millis() as u64
-                        }),
-                    );
-                    history_write = (
-                        crate::history::HistoryOutcome::Error,
-                        Some("发送线程异常".to_string()),
-                    );
                 }
             }
             (history_write, resume_continuous)

--- a/crates/kotone-core/src/orchestrator.rs
+++ b/crates/kotone-core/src/orchestrator.rs
@@ -430,6 +430,7 @@ impl Orchestrator {
         };
         let pcm_rx = handle.pcm_rx.take().expect("audio handle pcm channel");
         let level_rx = handle.level_rx.take().expect("audio handle level channel");
+        let audio_err_rx = handle.error_rx.take();
 
         let (stop_tx, stop_rx) = oneshot::channel::<()>();
         let (session_tx, session_rx) = oneshot::channel::<Box<dyn SttSession>>();
@@ -505,6 +506,7 @@ impl Orchestrator {
             let mut stop_rx = stop_rx;
             let mut pcm_rx = pcm_rx;
             let mut stt_rx = stt_rx;
+            let mut audio_err_rx = audio_err_rx;
             let mut vad_state = vad_state;
             // 松手收尾：end() 先停采集再发停止信号，pump 收到信号后把通道里
             // 已缓冲未消费的 PCM 全部灌进 session（松手丢字 P0：采音侧排空）；
@@ -590,6 +592,38 @@ impl Orchestrator {
                             }
                             None => break, // 采集结束
                         }
+                    }
+                    err = async {
+                        match &mut audio_err_rx {
+                            Some(rx) => rx.recv().await,
+                            // 无错误通道（mock/测试）：分支永不完成，不影响原有 select
+                            None => std::future::pending::<Option<String>>().await,
+                        }
+                    } => {
+                        if let Some(msg) = err {
+                            // 录音设备中途故障（拔麦克风/驱动错误）：中止会话并 toast，
+                            // 避免状态机永久停在 Listening 无感知（P1-⑤）
+                            emitter.emit(
+                                "kotone://process",
+                                json!({
+                                    "caseId": pump_case_id.clone(),
+                                    "activity": "session_aborted",
+                                    "data": { "outcome": "error", "errorCode": "AUDIO_DEVICE_ERROR" }
+                                }),
+                            );
+                            if let Some(me) = me_weak.as_ref().and_then(|w| w.upgrade()) {
+                                let msg2 = msg.clone();
+                                tokio::spawn(async move {
+                                    me.abort_with_message(&format!(
+                                        "{msg2}（本次会话已中止，请检查麦克风后重试）"
+                                    ))
+                                    .await;
+                                });
+                            }
+                            break;
+                        }
+                        // 通道关闭 = 采集线程正常退出（pcm 分支会收尾）；停用该分支防 busy 循环
+                        audio_err_rx = None;
                     }
                     ev = stt_rx.recv() => {
                         match ev {
@@ -837,6 +871,50 @@ impl Orchestrator {
         };
         self.do_send(final_text, gen).await;
         Ok(())
+    }
+
+    /// 录音设备故障等会话中止：与 cancel 相同清理，但以 Error toast 告知原因
+    /// （P1-⑤：拔麦克风/驱动错误不再永久卡 Listening）。
+    /// 无文本 Error → toast 后自动回 Idle（schedule_idle）。
+    pub async fn abort_with_message(&self, message: &str) {
+        // 宽限期倒计时一并收回
+        self.abort_release_grace();
+        let _op = self.op.lock().await;
+        let gen;
+        {
+            let mut inner = self.inner.lock().unwrap();
+            if inner.state == OrchestratorState::Idle {
+                return;
+            }
+            inner.gen += 1;
+            gen = inner.gen;
+            let mut active = inner.active.take();
+            inner.preview_text = None;
+            if let Some(token) = inner.send_cancel.take() {
+                token.cancel();
+            }
+            inner.state = OrchestratorState::Error;
+            drop(inner);
+            if let Some(a) = active.as_mut() {
+                a.cancelled_flag.store(true, Ordering::SeqCst);
+                if let Some(tx) = a.stop_tx.take() {
+                    let _ = tx.send(());
+                }
+                drop(a.guard.take());
+                a.pump.abort();
+                a.level_task.abort();
+            }
+        }
+        self.emit_state(
+            OrchestratorState::Error,
+            Some(json!({ "message": message })),
+        );
+        self.emit_process(
+            "session_aborted",
+            json!({ "outcome": "error", "errorCode": "AUDIO_DEVICE_ERROR" }),
+        );
+        self.write_history(crate::history::HistoryOutcome::Cancelled, None);
+        self.schedule_idle(gen);
     }
 
     /// 任意状态取消：回到 Idle（session cancel；发送中置取消令牌）

--- a/crates/kotone-core/tests/orchestrator.rs
+++ b/crates/kotone-core/tests/orchestrator.rs
@@ -293,6 +293,16 @@ fn make_orchestrator_full(
     injector: Arc<dyn Injector>,
     focus: Arc<dyn FocusBackend>,
 ) -> (Arc<Orchestrator>, Arc<VecEmitter>) {
+    make_orchestrator_tuned(auto_send, injector, focus, |_| {})
+}
+
+/// 同 make_orchestrator_full，但允许在 into_arc 前调整超时等字段（测试用）
+fn make_orchestrator_tuned(
+    auto_send: bool,
+    injector: Arc<dyn Injector>,
+    focus: Arc<dyn FocusBackend>,
+    tune: impl FnOnce(&mut Orchestrator),
+) -> (Arc<Orchestrator>, Arc<VecEmitter>) {
     let mut settings = Settings::default();
     // 0.1.5 起默认交互模式为「对讲机」（hold 直发）；本测试族沿用旧的
     // toggle + autoSend 推导行为，显式置 None 走自定义兼容路径
@@ -321,6 +331,7 @@ fn make_orchestrator_full(
     orch.finalize_timeout = Duration::from_secs(2);
     orch.focus_restore_delay = Duration::ZERO;
     orch.release_grace = Duration::from_millis(10); // 测试用小宽限期
+    tune(&mut orch);
     (orch.into_arc(), emitter)
 }
 
@@ -454,6 +465,27 @@ async fn begin_with_unready_engine_toasts_error() {
     assert!(emitter.state_sequence().contains(&"error".to_string()));
 }
 
+/// 发送挂起模拟（SendInput 被安全软件钩住不返回）：首次调用阻塞 hang_ms，
+/// 之后立即成功（验证 inject_timeout 超时兜底回 Error 态 + 重试可恢复，P0）。
+struct HangingInjector {
+    hang_ms: u64,
+    hung: Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl Injector for HangingInjector {
+    fn send(
+        &self,
+        _text: &str,
+        _profile: &GameProfile,
+        _cancel: CancelToken,
+    ) -> Result<(), InjectError> {
+        if self.hung.swap(false, Ordering::SeqCst) {
+            std::thread::sleep(Duration::from_millis(self.hang_ms));
+        }
+        Ok(())
+    }
+}
+
 /// §4.1：Error 保留文本可重试——confirm_send 在 Error 状态重新进入 Sending
 #[tokio::test]
 async fn error_state_retains_text_and_confirm_send_retries() {
@@ -496,6 +528,61 @@ async fn error_state_retains_text_and_confirm_send_retries() {
     // Success 仍按 toast 节奏自动回 Idle
     tokio::time::sleep(Duration::from_millis(50)).await;
     assert_eq!(orch.state(), OrchestratorState::Idle);
+}
+
+/// P0：SendInput 挂起（被安全软件钩住不返回）时，inject_timeout 兜底回 Error 态。
+/// 状态机不能永久卡在 Sending；Error 保留文本，后续可重试。
+#[tokio::test]
+async fn inject_timeout_falls_back_to_error_state_and_retry() {
+    let injector: Arc<dyn Injector> = Arc::new(HangingInjector {
+        hang_ms: 300,
+        hung: Arc::new(std::sync::atomic::AtomicBool::new(true)),
+    });
+    let focus: Arc<dyn FocusBackend> =
+        Arc::new(MockFocusBackend::new(Arc::new(Mutex::new(Vec::new())), 42, true));
+    let (orch, emitter) = make_orchestrator_tuned(false, injector, focus, |o| {
+        o.inject_timeout = Duration::from_millis(50); // 挂起 300ms >> 超时 50ms
+    });
+
+    orch.begin().await.unwrap();
+    tokio::time::sleep(Duration::from_millis(60)).await;
+    orch.end().await.unwrap();
+    assert_eq!(orch.state(), OrchestratorState::Preview);
+
+    orch.confirm_send().await.unwrap();
+    // 超时兜底：状态必须离开 Sending，进入 Error（保留文本）
+    assert_eq!(orch.state(), OrchestratorState::Error);
+    let seq = emitter.state_sequence();
+    assert_eq!(
+        seq.last().map(String::as_str),
+        Some("error"),
+        "注入超时应回 Error 态而非永久卡 Sending: {seq:?}"
+    );
+    let err_msg = emitter
+        .events
+        .lock()
+        .unwrap()
+        .iter()
+        .rev()
+        .find(|(e, p)| e == "kotone://state" && p["state"] == "error")
+        .and_then(|(_, p)| p["payload"]["message"].as_str().map(String::from))
+        .unwrap_or_default();
+    assert!(err_msg.contains("超时"), "错误信息应含超时提示: {err_msg}");
+    assert!(
+        emitter
+            .events
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|(e, p)| e == "kotone://state"
+                && p["state"] == "error"
+                && p["payload"]["text"] == "对面打野在下路"),
+        "Error 态应保留文本供重试"
+    );
+
+    // 重试：第二次发送不再挂起，Error 态 confirm_send 重新进入 Sending 并成功
+    orch.confirm_send().await.unwrap();
+    assert_eq!(orch.state(), OrchestratorState::Success);
 }
 
 /// Error 状态下可带编辑后文本重试

--- a/crates/kotone-core/tests/orchestrator.rs
+++ b/crates/kotone-core/tests/orchestrator.rs
@@ -538,8 +538,11 @@ async fn inject_timeout_falls_back_to_error_state_and_retry() {
         hang_ms: 300,
         hung: Arc::new(std::sync::atomic::AtomicBool::new(true)),
     });
-    let focus: Arc<dyn FocusBackend> =
-        Arc::new(MockFocusBackend::new(Arc::new(Mutex::new(Vec::new())), 42, true));
+    let focus: Arc<dyn FocusBackend> = Arc::new(MockFocusBackend::new(
+        Arc::new(Mutex::new(Vec::new())),
+        42,
+        true,
+    ));
     let (orch, emitter) = make_orchestrator_tuned(false, injector, focus, |o| {
         o.inject_timeout = Duration::from_millis(50); // 挂起 300ms >> 超时 50ms
     });

--- a/crates/kotone-platform-windows/src/audio.rs
+++ b/crates/kotone-platform-windows/src/audio.rs
@@ -70,13 +70,15 @@ impl AudioBackend for CpalBackend {
     fn start(&self, device_id: &str) -> Result<AudioHandle, String> {
         let (pcm_tx, pcm_rx) = mpsc::unbounded_channel::<Vec<f32>>();
         let (level_tx, level_rx) = mpsc::unbounded_channel::<f32>();
+        // 采集中途故障（拔设备/驱动错误）经此上报 orchestrator，避免永久 Listening
+        let (error_tx, error_rx) = mpsc::unbounded_channel::<String>();
         let (stop_tx, stop_rx) = std::sync::mpsc::channel::<()>();
         // 设备打开结果回传：start 同步返回清晰错误，而不是等回调失败
         let (open_tx, open_rx) = std::sync::mpsc::channel::<Result<(), String>>();
 
         let device_id = device_id.to_string();
         let thread = std::thread::spawn(move || {
-            match open_stream(&device_id, pcm_tx, level_tx) {
+            match open_stream(&device_id, pcm_tx, level_tx, error_tx) {
                 Ok(input) => {
                     let _ = open_tx.send(Ok(()));
                     // 流存活期间阻塞等待停止信号；stream 随作用域结束释放
@@ -90,7 +92,7 @@ impl AudioBackend for CpalBackend {
         });
 
         match open_rx.recv() {
-            Ok(Ok(())) => Ok(AudioHandle::with_thread(pcm_rx, level_rx, stop_tx, thread)),
+            Ok(Ok(())) => Ok(AudioHandle::with_thread(pcm_rx, level_rx, error_rx, stop_tx, thread)),
             Ok(Err(e)) => {
                 let _ = thread.join();
                 Err(e)
@@ -127,6 +129,7 @@ fn open_stream(
     device_id: &str,
     pcm_tx: mpsc::UnboundedSender<Vec<f32>>,
     level_tx: mpsc::UnboundedSender<f32>,
+    error_tx: mpsc::UnboundedSender<String>,
 ) -> Result<OpenedInput, String> {
     let host = cpal::default_host();
     let device = if device_id == "default" || device_id.is_empty() {
@@ -149,22 +152,25 @@ fn open_stream(
     let stream_config: cpal::StreamConfig = config.clone().into();
     let state = std::sync::Arc::new(std::sync::Mutex::new(CaptureState::new(sample_rate)));
 
-    let err_fn = |e| eprintln!("[kotone audio] 采集错误: {e}");
-
     let stream = match config.sample_format() {
         cpal::SampleFormat::F32 => {
             let state = state.clone();
             let pcm_tx = pcm_tx.clone();
             let level_tx = level_tx.clone();
+            let error_tx = error_tx.clone();
             device.build_input_stream(
                 &stream_config,
                 move |data: &[f32], _| {
                     state
                         .lock()
-                        .unwrap()
+                        .unwrap_or_else(|p| p.into_inner())
                         .push_interleaved(data, channels, &pcm_tx, &level_tx)
                 },
-                err_fn,
+                move |e| {
+                    eprintln!("[kotone audio] 采集错误: {e}");
+                    // 上报 orchestrator：中止会话并提示（避免永久 Listening 无感知）
+                    let _ = error_tx.send(format!("录音设备出错：{e}"));
+                },
                 None,
             )
         }
@@ -172,6 +178,7 @@ fn open_stream(
             let state = state.clone();
             let pcm_tx = pcm_tx.clone();
             let level_tx = level_tx.clone();
+            let error_tx = error_tx.clone();
             device.build_input_stream(
                 &stream_config,
                 move |data: &[i16], _| {
@@ -181,10 +188,13 @@ fn open_stream(
                         .collect();
                     state
                         .lock()
-                        .unwrap()
+                        .unwrap_or_else(|p| p.into_inner())
                         .push_interleaved(&f, channels, &pcm_tx, &level_tx);
                 },
-                err_fn,
+                move |e| {
+                    eprintln!("[kotone audio] 采集错误: {e}");
+                    let _ = error_tx.send(format!("录音设备出错：{e}"));
+                },
                 None,
             )
         }
@@ -192,6 +202,7 @@ fn open_stream(
             let state = state.clone();
             let pcm_tx = pcm_tx.clone();
             let level_tx = level_tx.clone();
+            let error_tx = error_tx.clone();
             device.build_input_stream(
                 &stream_config,
                 move |data: &[u16], _| {
@@ -201,10 +212,13 @@ fn open_stream(
                         .collect();
                     state
                         .lock()
-                        .unwrap()
+                        .unwrap_or_else(|p| p.into_inner())
                         .push_interleaved(&f, channels, &pcm_tx, &level_tx);
                 },
-                err_fn,
+                move |e| {
+                    eprintln!("[kotone audio] 采集错误: {e}");
+                    let _ = error_tx.send(format!("录音设备出错：{e}"));
+                },
                 None,
             )
         }

--- a/crates/kotone-platform-windows/src/audio.rs
+++ b/crates/kotone-platform-windows/src/audio.rs
@@ -92,7 +92,9 @@ impl AudioBackend for CpalBackend {
         });
 
         match open_rx.recv() {
-            Ok(Ok(())) => Ok(AudioHandle::with_thread(pcm_rx, level_rx, error_rx, stop_tx, thread)),
+            Ok(Ok(())) => Ok(AudioHandle::with_thread(
+                pcm_rx, level_rx, error_rx, stop_tx, thread,
+            )),
             Ok(Err(e)) => {
                 let _ = thread.join();
                 Err(e)

--- a/crates/kotone-platform-windows/src/inject.rs
+++ b/crates/kotone-platform-windows/src/inject.rs
@@ -185,10 +185,23 @@ mod windows_imp {
             Ok(())
         } else {
             let err = windows::core::Error::from_win32();
-            // 0/N 全部未落地 = 系统级拦截（安全软件主动防御 / 游戏反作弊在内核层
-            // 丢弃合成输入），与目标窗口无关——连记事本都会失败。单独标记让前端
-            // 弹窗引导排查；部分落地（N>0）仍是普通失败（时序/焦点干扰）。
+            // 0/N 全部未落地 = 系统级拦截。两类成因需要不同指引：
+            // 1) UIPI：目标进程完整性级别更高（如管理员运行的游戏），SendInput 被
+            //    拒绝——Win32 文档明示返回值与 GetLastError 均不保证指示 UIPI，但
+            //    ERROR_ACCESS_DENIED 出现时优先归因提权场景（提权可解）；
+            // 2) 安全软件主动防御 / 反作弊内核层拦截——与目标窗口无关，连记事本都
+            //    会失败，单独标记让前端弹窗引导排查（提权无法解决）。
+            // 部分落地（N>0）仍是普通失败（时序/焦点干扰）。
             if sent == 0 {
+                use windows::Win32::Foundation::ERROR_ACCESS_DENIED;
+                if err.code().0 as u32 == ERROR_ACCESS_DENIED.0 {
+                    return Err(InjectError::with_needs_elevation(format!(
+                        "SendInput 被拒绝（0/{} 成功）：目标程序可能以更高权限运行\
+                         （如管理员模式启动的游戏）。请以管理员身份运行 Kotone，\
+                         或将目标程序改为普通权限: {err}",
+                        inputs.len()
+                    )));
+                }
                 return Err(InjectError::with_input_blocked(format!(
                     "SendInput 被系统拦截（0/{} 成功），通常是安全软件或游戏反作弊拦截了模拟输入: {err}",
                     inputs.len()

--- a/crates/kotone-platform-windows/src/wav_audio.rs
+++ b/crates/kotone-platform-windows/src/wav_audio.rs
@@ -68,7 +68,13 @@ impl AudioBackend for WavFileBackend {
             // 文件喂完：tx 随线程结束 drop，通道关闭 → pump 收尾
         });
 
-        Ok(AudioHandle::with_thread(pcm_rx, level_rx, stop_tx, thread))
+        Ok(AudioHandle::with_thread(
+            pcm_rx,
+            level_rx,
+            mpsc::unbounded_channel::<String>().1,
+            stop_tx,
+            thread,
+        ))
     }
 }
 

--- a/crates/kotone-stt/src/download.rs
+++ b/crates/kotone-stt/src/download.rs
@@ -10,6 +10,7 @@
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Write};
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use kotone_core::settings::{DownloadConfig, DownloadSource};
@@ -22,6 +23,39 @@ pub type Progress<'a> = &'a dyn Fn(u64, Option<u64>);
 
 /// 单块读取大小（256KB：进度足够平滑，syscall 又不至于太密）
 const CHUNK: usize = 256 * 1024;
+
+// ---------- 下载取消与并发互斥（P2-⑦） ----------
+
+/// 全局取消标记：IPC `cancel_download` 置位；下载循环每块检查。
+/// 取消不删除 `.part` 临时文件（下次启动自动断点续传）。
+static CANCEL_REQUESTED: AtomicBool = AtomicBool::new(false);
+/// 下载互斥：GUI 与 CLI 共用同一实现，防并发重复下载同一模型
+static DOWNLOAD_ACTIVE: AtomicBool = AtomicBool::new(false);
+
+/// 请求取消当前下载（幂等）
+pub fn request_cancel() {
+    CANCEL_REQUESTED.store(true, Ordering::SeqCst);
+}
+
+/// 下载循环是否应中止（每块读/每次候选回退前检查）
+pub fn cancel_requested() -> bool {
+    CANCEL_REQUESTED.load(Ordering::SeqCst)
+}
+
+/// 进入下载临界区：已有下载进行中时拒绝（IPC 并发防重入）
+pub fn begin_download() -> Result<(), String> {
+    if DOWNLOAD_ACTIVE.swap(true, Ordering::SeqCst) {
+        return Err("已有模型下载进行中，请等待完成或先取消".to_string());
+    }
+    CANCEL_REQUESTED.store(false, Ordering::SeqCst);
+    Ok(())
+}
+
+/// 退出下载临界区（无论成败）：释放互斥并复位取消标记
+pub fn end_download() {
+    DOWNLOAD_ACTIVE.store(false, Ordering::SeqCst);
+    CANCEL_REQUESTED.store(false, Ordering::SeqCst);
+}
 /// ModelScope 的 LFS CDN 会拒绝没有 User-Agent 的匿名请求（403）。
 /// 使用固定、可识别的应用标识；公开模型下载不需要用户 Token。
 const USER_AGENT: &str = concat!("Kotone/", env!("CARGO_PKG_VERSION"), " model-downloader");
@@ -147,6 +181,10 @@ fn download_to_tmp(url: &str, tmp: &Path, progress: Progress<'_>) -> Result<(), 
     progress(downloaded, total);
     let mut buf = vec![0u8; CHUNK];
     loop {
+        if cancel_requested() {
+            // 取消：保留 .part 供续传（与网络中断同语义，不删临时文件）
+            return Err("下载已取消（临时文件已保留，可随时续传）".to_string());
+        }
         let n = resp.read(&mut buf).map_err(|e| format!("下载中断：{e}"))?;
         if n == 0 {
             break;
@@ -245,6 +283,9 @@ pub fn download_resolved(
     let candidates = candidate_urls(url, cfg);
     let mut last_err = String::new();
     for (i, cand) in candidates.iter().enumerate() {
+        if cancel_requested() {
+            return Err("下载已取消（临时文件已保留，可随时续传）".to_string());
+        }
         if i > 0 {
             log(&format!("镜像失败，回退重试：{cand}"));
         }

--- a/crates/kotone-stt/src/model.rs
+++ b/crates/kotone-stt/src/model.rs
@@ -919,9 +919,43 @@ pub fn migrate_dir_contents(src: &PathBuf, dst: &PathBuf) -> Result<MigrateRepor
         let name = entry.file_name().to_string_lossy().into_owned();
         let target = dst.join(&name);
         if target.exists() {
-            // 目标已有同名条目：视为已迁移（保留目标，删除源以完成合并）
-            if remove_entry(&entry.path()).is_ok() {
-                report.moved.push(name);
+            // 目标已有同名条目（重复迁移/目标目录本有内容）。不能盲目删源：
+            // - 同名同大小文件：视为已迁移（保留目标，删除源完成合并）；
+            // - 同名不同内容文件：删源会静默丢数据——源改名为 conflict 副本保留；
+            // - 同名目录：保守处理，不合并不删除，记 failed 交用户处理。
+            let src_is_file = entry.path().is_file();
+            let same_size = src_is_file
+                && fs::metadata(&entry.path())
+                    .and_then(|s| fs::metadata(&target).map(|t| (s.len(), t.len())))
+                    .map(|(a, b)| a == b)
+                    .unwrap_or(false);
+            if same_size {
+                if remove_entry(&entry.path()).is_ok() {
+                    report.moved.push(name);
+                } else {
+                    report.failed.push(name);
+                }
+            } else if src_is_file {
+                let ts = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_secs())
+                    .unwrap_or(0);
+                let conflict = dst.join(format!("{name}.conflict-{ts}"));
+                match fs::rename(&entry.path(), &conflict) {
+                    Ok(()) => {
+                        kotone_core::log::log(&format!(
+                            "模型迁移：目标已有同名不同内容文件，源保留为 {}",
+                            conflict.display()
+                        ));
+                        report.moved.push(name);
+                    }
+                    Err(e) => {
+                        kotone_core::log::log(&format!(
+                            "模型迁移：同名冲突文件改名失败（{name}）: {e}"
+                        ));
+                        report.failed.push(name);
+                    }
+                }
             } else {
                 report.failed.push(name);
             }
@@ -1521,6 +1555,52 @@ mod tests {
         let report = migrate_dir_contents(&p, &dst).unwrap();
         assert!(report.moved.is_empty() && report.failed.is_empty());
         assert!(dst.exists());
+    }
+
+    /// P2-⑧：目标已有同名条目时不得静默删源——
+    /// 同大小文件视为已迁移；不同内容文件保留为 conflict 副本；同名目录记 failed。
+    #[test]
+    fn migrate_preserves_conflicting_same_name_entries() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("old");
+        let dst = tmp.path().join("new");
+        fs::create_dir_all(&src).unwrap();
+        fs::create_dir_all(&dst).unwrap();
+
+        // 1) 同名同大小文件：视为已迁移，源删除
+        fs::write(src.join("same.bin"), b"abc").unwrap();
+        fs::write(dst.join("same.bin"), b"abc").unwrap();
+        // 2) 同名不同内容文件：源保留为 conflict 副本，不丢数据
+        fs::write(src.join("diff.bin"), b"old-content").unwrap();
+        fs::write(dst.join("diff.bin"), b"new-content-longer").unwrap();
+        // 3) 同名目录：保守记 failed，源目录原样保留
+        fs::create_dir_all(src.join("dir")).unwrap();
+        fs::create_dir_all(dst.join("dir")).unwrap();
+
+        let report = migrate_dir_contents(&src, &dst).unwrap();
+        assert!(
+            report.moved.contains(&"same.bin".to_string()),
+            "同大小文件应视为已迁移: {report:?}"
+        );
+        assert!(
+            report.moved.contains(&"diff.bin".to_string()),
+            "冲突文件应改名保留并计入 moved: {report:?}"
+        );
+        assert!(report.failed.contains(&"dir".to_string()), "{report:?}");
+
+        assert!(!src.join("same.bin").exists(), "同大小源应删除");
+        assert_eq!(fs::read(dst.join("diff.bin")).unwrap(), b"new-content-longer");
+        let conflicts = fs::read_dir(&dst)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.starts_with("diff.bin.conflict-"))
+            .count();
+        assert_eq!(conflicts, 1, "冲突源应保留为 conflict 副本");
+        assert!(
+            src.join("dir").is_dir(),
+            "同名目录冲突时源目录不应被删除"
+        );
     }
 
     // ---------- 删除 ----------

--- a/crates/kotone-stt/src/model.rs
+++ b/crates/kotone-stt/src/model.rs
@@ -412,7 +412,31 @@ pub fn list() -> Result<Vec<ModelInfo>, String> {
 /// 下载模型（id = 清单内任意模型 / silero-vad），进度经回调外发
 /// （多文件模型聚合进度）。阻塞实现：调用方放阻塞线程。
 /// 下载源策略（镜像 / 回退）取 settings.download，见 download.rs。
+/// 全局互斥 + 取消标记（P2-⑦）：并发重复下载被拒绝；cancel_download 可中断。
 pub fn download(id: &str, progress: Progress<'_>) -> Result<(), String> {
+    download::begin_download().map_err(|e| e.to_string())?;
+    let result = download_inner(id, progress);
+    download::end_download();
+    result
+}
+
+/// 请求取消当前下载（幂等；Tauri IPC 用）
+pub fn cancel_download() {
+    download::request_cancel();
+}
+
+/// 模型清单内模型的总大小（磁盘空间预检用；未知返回 None）
+pub fn model_size_bytes(id: &str) -> Option<u64> {
+    if id == VAD_MODEL_ID {
+        return Some(VAD_MODEL_SIZE);
+    }
+    SHERPA_MODELS
+        .iter()
+        .find(|m| m.id == id)
+        .map(|m| m.files.iter().map(|f| f.size_bytes).sum())
+}
+
+fn download_inner(id: &str, progress: Progress<'_>) -> Result<(), String> {
     let cfg = settings::load().download;
     if id == VAD_MODEL_ID {
         let dest = vad_model_path();

--- a/crates/kotone-stt/src/model.rs
+++ b/crates/kotone-stt/src/model.rs
@@ -920,16 +920,21 @@ pub fn migrate_dir_contents(src: &PathBuf, dst: &PathBuf) -> Result<MigrateRepor
         let target = dst.join(&name);
         if target.exists() {
             // 目标已有同名条目（重复迁移/目标目录本有内容）。不能盲目删源：
-            // - 同名同大小文件：视为已迁移（保留目标，删除源完成合并）；
+            // - 同名同内容文件：视为已迁移（保留目标，删除源完成合并）；
             // - 同名不同内容文件：删源会静默丢数据——源改名为 conflict 副本保留；
             // - 同名目录：保守处理，不合并不删除，记 failed 交用户处理。
             let src_is_file = entry.path().is_file();
-            let same_size = src_is_file
+            let same_content = src_is_file
                 && fs::metadata(&entry.path())
                     .and_then(|s| fs::metadata(&target).map(|t| (s.len(), t.len())))
                     .map(|(a, b)| a == b)
+                    .unwrap_or(false)
+                && download::sha256_file(&entry.path())
+                    .and_then(|src_hash| {
+                        download::sha256_file(&target).map(|target_hash| src_hash == target_hash)
+                    })
                     .unwrap_or(false);
-            if same_size {
+            if same_content {
                 if remove_entry(&entry.path()).is_ok() {
                     report.moved.push(name);
                 } else {
@@ -1558,7 +1563,8 @@ mod tests {
     }
 
     /// P2-⑧：目标已有同名条目时不得静默删源——
-    /// 同大小文件视为已迁移；不同内容文件保留为 conflict 副本；同名目录记 failed。
+    /// 同内容文件视为已迁移；不同内容文件（包括同大小）保留为 conflict 副本；
+    /// 同名目录记 failed。
     #[test]
     fn migrate_preserves_conflicting_same_name_entries() {
         let tmp = tempfile::tempdir().unwrap();
@@ -1567,29 +1573,39 @@ mod tests {
         fs::create_dir_all(&src).unwrap();
         fs::create_dir_all(&dst).unwrap();
 
-        // 1) 同名同大小文件：视为已迁移，源删除
+        // 1) 同名同内容文件：视为已迁移，源删除
         fs::write(src.join("same.bin"), b"abc").unwrap();
         fs::write(dst.join("same.bin"), b"abc").unwrap();
-        // 2) 同名不同内容文件：源保留为 conflict 副本，不丢数据
+        // 2) 同名不同长度文件：源保留为 conflict 副本，不丢数据
         fs::write(src.join("diff.bin"), b"old-content").unwrap();
         fs::write(dst.join("diff.bin"), b"new-content-longer").unwrap();
-        // 3) 同名目录：保守记 failed，源目录原样保留
+        // 3) 同名同长度但内容不同：也必须保留为 conflict 副本
+        fs::write(src.join("same-size.bin"), b"abc").unwrap();
+        fs::write(dst.join("same-size.bin"), b"xyz").unwrap();
+        // 4) 同名目录：保守记 failed，源目录原样保留
         fs::create_dir_all(src.join("dir")).unwrap();
         fs::create_dir_all(dst.join("dir")).unwrap();
 
         let report = migrate_dir_contents(&src, &dst).unwrap();
         assert!(
             report.moved.contains(&"same.bin".to_string()),
-            "同大小文件应视为已迁移: {report:?}"
+            "同内容文件应视为已迁移: {report:?}"
         );
         assert!(
             report.moved.contains(&"diff.bin".to_string()),
             "冲突文件应改名保留并计入 moved: {report:?}"
         );
+        assert!(
+            report.moved.contains(&"same-size.bin".to_string()),
+            "同长度但内容不同的冲突文件也应改名保留: {report:?}"
+        );
         assert!(report.failed.contains(&"dir".to_string()), "{report:?}");
 
-        assert!(!src.join("same.bin").exists(), "同大小源应删除");
-        assert_eq!(fs::read(dst.join("diff.bin")).unwrap(), b"new-content-longer");
+        assert!(!src.join("same.bin").exists(), "同内容源应删除");
+        assert_eq!(
+            fs::read(dst.join("diff.bin")).unwrap(),
+            b"new-content-longer"
+        );
         let conflicts = fs::read_dir(&dst)
             .unwrap()
             .filter_map(|e| e.ok())
@@ -1597,10 +1613,17 @@ mod tests {
             .filter(|n| n.starts_with("diff.bin.conflict-"))
             .count();
         assert_eq!(conflicts, 1, "冲突源应保留为 conflict 副本");
-        assert!(
-            src.join("dir").is_dir(),
-            "同名目录冲突时源目录不应被删除"
+        let same_size_conflicts = fs::read_dir(&dst)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.starts_with("same-size.bin.conflict-"))
+            .count();
+        assert_eq!(
+            same_size_conflicts, 1,
+            "同长度冲突源也应保留为 conflict 副本"
         );
+        assert!(src.join("dir").is_dir(), "同名目录冲突时源目录不应被删除");
     }
 
     // ---------- 删除 ----------


### PR DESCRIPTION
## 背景

基于对项目的架构分析与用户旅程分析（用户反馈两类问题：① 新手引导下载模型应支持选择下载路径而不是默认 C 盘；② SendInput 被 360 拦截后软件卡死退出），经评审批准后实施以下 10 项改进，每项一个 commit。

## 10 项改动（P0 → P2）

### P0 — 卡死问题（用户反馈 ②）
1. **fix(core): 注入发送加 10s 超时兜底** — `do_send` 对 `spawn_blocking(injector.send)` 加超时（对齐 finalize 的 10s），SendInput 被安全软件钩住挂起时状态机回到 Error 态（保留文本可重试），不再永久卡 Sending。含挂起注入器集成测试。
2. **fix(tauri): simulate_send 改 async + spawn_blocking + 10s 超时** — 同步命令此前在主线程直接调 SendInput，挂起=整机冻结；悬浮窗错误重试路径获得同等保护。

### P1
3. **feat(ui): 新手向导支持选择模型下载路径**（用户反馈 ①）— 向导第 2 步新增「模型存储位置」卡片（文件夹选择器/恢复默认/打开目录，切换即迁移）；高级页目录编辑增加「浏览…」按钮。
4. **fix(inject): UIPI 提权拦截与安全软件拦截分流** — SendInput 0/N 且 GetLastError==ERROR_ACCESS_DENIED 时标记 needs_elevation（管理员游戏场景），不再被误诊为「安全软件拦截」；悬浮窗显示提权提示。
5. **fix(audio): 录音设备中途故障上报 orchestrator 中止会话** — 拔麦克风/驱动错误不再永久卡 Listening，Error toast 提示后自动回 Idle。

### P2
6. **feat(ui): 主页模型下载直达入口 + 向导拦截逃生门** — 跳过向导/删除模型后主页横幅一键下载；探针拦截时可选「仍然继续（风险自担）」不被卡在向导。
7. **feat(download): 磁盘空间预检 + 下载取消 + 并发互斥** — 下载前检查模型目录所在卷剩余空间；取消按钮（.part 保留可续传）；GUI/CLI 共用互斥防并发重复下载。
8. **fix(models): 迁移前检查运行相位，同名冲突条目不再静默删源** — 引擎 Running 时拒绝迁移；同名不同内容文件保留为 conflict 副本。含冲突迁移测试。
9. **feat(settings): 历史记录目录可自定义** — HistoryConfig 新增 dir，高级页新增「历史记录位置」管理（含音频）。
10. **feat(ui): 键位冲突静态提示接入向导热键步骤** — detect_conflicts 去 dead_code，录入热键后内联展示冲突提示。

## 验证

- `cargo test --workspace`：247 个测试全部通过（含新增注入超时、迁移冲突测试）
- `pnpm check`（svelte-check）：0 错误 0 警告
- 未修改任何分析产物（.tmp-analysis/ 未纳入本分支）

## 备注

- 注入超时后阻塞线程无法回收（SendInput 挂起属系统级行为），超时错误信息已提示用户可重试或重启引擎；
- 历史目录切换不自动迁移旧内容（新记录写入新目录），UI 已注明。