### PR TITLE
fix(fmt): 把屏蔽词描述收成 rustfmt 一行

### DIFF
--- a/crates/kotone-postprocess/src/blocklist.rs
+++ b/crates/kotone-postprocess/src/blocklist.rs
@@ -49,8 +49,7 @@ impl ProcessorFactory for BlocklistFilterFactory {
             config_fields: vec![ProcessorConfigField {
                 key: "csvPath".into(),
                 display_name: "自己的词库".into(),
-                description: "不选就用默认词库。选了文件就改用你的。"
-                    .into(),
+                description: "不选就用默认词库。选了文件就改用你的。".into(),
                 kind: ProcessorConfigFieldKind::File,
                 required: false,
                 file_extensions: vec!["csv".into()],


### PR DESCRIPTION
CI `cargo fmt --check` 在 `blocklist.rs` 的描述字符串换行处失败。